### PR TITLE
Gnome 3.34 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -60,7 +60,7 @@ const AudioOutputSubMenu = class AudioOutputSubMenu extends PopupMenu.PopupSubMe
 
 	destroy() {
 		this._control.disconnect(this._controlSignal);
-		this.parent();
+		super.destroy();
 	}
 }
 

--- a/extension.js
+++ b/extension.js
@@ -3,13 +3,15 @@ const Meta = imports.gi.Meta;
 const Main = imports.ui.main;
 const PopupMenu = imports.ui.popupMenu;
 const Shell = imports.gi.Shell;
+const GObject = imports.gi.GObject;
 
 const Me = ExtensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 
-const AudioOutputSubMenu = class AudioOutputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
-	constructor() {
-		super("Audio Output: Connecting...", true);
+var AudioOutputSubMenu = GObject.registerClass(
+	class AudioOutputSubMenu extends PopupMenu.PopupSubMenuMenuItem {
+	_init() {
+		super._init("Audio Output: Connecting...", true);
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
 		this._controlSignal = this._control.connect('default-sink-changed', () => {
@@ -62,7 +64,7 @@ const AudioOutputSubMenu = class AudioOutputSubMenu extends PopupMenu.PopupSubMe
 		this._control.disconnect(this._controlSignal);
 		super.destroy();
 	}
-}
+});
 
 let sinkIndex = 0;
 let settings = null;


### PR DESCRIPTION
Plugin fails to load after the Gnome 3.34 update, updating the class definition allows it to be loaded again