### PR TITLE
Fix TypeError on Manjaro/steelseries head set

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -15,7 +15,9 @@ const AudioOutputSubMenu = GObject.registerClass(
 		this._control = Main.panel.statusArea.aggregateMenu._volume._control;
 
 		this._controlSignal = this._control.connect('default-sink-changed', () => {
-			this._updateDefaultSink();
+			if (this._updateDefaultSink) {
+				this._updateDefaultSink();
+			}
 		});
 		this._updateDefaultSink();
 		this.menu.connect('open-state-changed', (menu, isOpen) => {


### PR DESCRIPTION
After system update to gnome 3.34, the extension stopped to load with error:

```
Archive:  /tmp/L47U9Z.shell-extension.zip
  inflating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/extension.js
  inflating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/README.md
  inflating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/LICENSE
   creating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/schemas/
  inflating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/schemas/gschemas.compiled
  inflating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/utils.js
  inflating: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/schemas/org.gnome.shell.extensions.audio-output-switcher.gschema.xml
 extracting: /home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/metadata.json
JS ERROR: Extension audio-output-switcher@anduchs: TypeError: this._updateDefaultSink is not a function
AudioOutputSubMenu@/home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/extension.js:18:3
enable@/home/azhidkov/.local/share/gnome-shell/extensions/audio-output-switcher@anduchs/extension.js:80:23
_callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:131:13
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:263:21
callback@resource:///org/gnome/shell/ui/extensionDownloader.js:232:17
gotExtensionZipFile/<@resource:///org/gnome/shell/ui/extensionDownloader.js:99:13
```

I'm not expert in gnome shell extensions nor js not gjs, but this fix works for me