### PR TITLE
Added gnome shell 40 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "shell-version": [
         "3.34",
         "3.36",
-        "3.38"
+        "3.38",
+        "40"
     ],
     "uuid": "audio-output-switcher@anduchs",
     "name": "Audio Output Switcher",


### PR DESCRIPTION
Adding shell version 40 is sufficient to make it work in Gnome Shell 40. No code changes required.